### PR TITLE
set defaultViewPort option for puppeteer (#167)

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -6,7 +6,8 @@ exports.UserAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit
 
 exports.DefaultOptions = {
     puppeteer: {
-        headless: true
+        headless: true,
+        defaultViewport: null
     },
     session: false,
     qrTimeoutMs: 45000,


### PR DESCRIPTION
- Mainly for those who like to keep the GUI open.
- Expands to fit and looks like it usually would.